### PR TITLE
Compare by Name + Attribute

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,10 +2,10 @@
 
 Agent guide for **tracer** — a scientific OTLP trace observatory. A Bun API
 server (the middle layer between Grafana Tempo and clients) serves a React
-SPA plus an agent-first REST API; together they render and expose
-multi-instance traces: spans from separate nodes executing the same protocol
-(e.g. a `commonware` consensus cluster) overlaid on one trace, deduplicated
-and split per instance.
+SPA plus an agent-first REST API. Each node of a distributed system (e.g. a
+`commonware` consensus cluster) emits its OWN trace; tracer correlates the same
+span across those separate traces by name + attribute and renders one
+multi-instance comparison (lanes per node).
 
 ## Commands
 
@@ -136,10 +136,13 @@ virtualization). Canvas precomputes layout — no per-frame allocations; keep
 - Three time units, never mixed: search ranges are unix **seconds**,
   `startUnixMs` anchors are epoch **milliseconds**, every `*Ns` field is
   **nanoseconds** relative to the trace start.
-- Cross-node traces: every node shares a deterministic trace id per round, so
-  one trace holds all nodes' spans; the parser splits them into `Instance`s
-  (identity: `service.name` + optional `#service.instance.id`) and dedupes
-  spans by id (first wins, with a warning).
+- Each node emits its OWN trace; a fetched trace is one node. Cross-node views
+  are built by the compare route (`assembleFromQuery` + `assembleComparison`):
+  it correlates the same span across separate traces by name + attribute and
+  assembles one synthetic multi-instance trace (`Instance` identity:
+  `service.name` + optional `#service.instance.id`; lanes share a time axis
+  anchored at the earliest match so start skew is visible, ids instance-prefixed).
+  `/compare/aggregate` is the cross-node code-path view.
 - Tempo search returns an unordered subset — the windowed newest-first search
   in `TempoClient` is what makes "latest N" deterministic. Don't bypass it.
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ Distributed systems emit one logical operation (a consensus round, a quorum, a
 broadcast) across many nodes at once. Most viewers show you one node's spans at
 a time. tracer is built around the cross-node view:
 
-- **One trace, every node.** When nodes share a trace id for the same round,
-  tracer lays each instance out on its own lane on a shared time axis — so you
-  see who started late, who stalled, and how the work overlapped across the
+- **One lane per node.** Each node emits its own trace; **Compare** correlates
+  the same span across them by name + attribute (e.g. `simplex.voter.view`,
+  `view=1612`) and lays each node out on its own lane on a shared time axis — so
+  you see who started late, who stalled, and how the work overlapped across the
   cluster.
 - **Merged aggregate flame.** Collapse all instances onto one flame, each span
   split into per-instance sub-bars, to compare the same code path across nodes.
@@ -88,8 +89,8 @@ nodes emit one consensus round per second. Stop it with `just demo-down`. See
 
 Every deployment serves a typed REST API under `/api/v1` — the middle layer
 between Tempo and clients. It does what the UI's engine does (deterministic
-newest-first search, OTLP parsing, span dedup, per-instance splitting,
-cross-instance aggregation) and returns compact, schema-stable JSON:
+newest-first search, OTLP parsing, span dedup, and cross-node correlation of one
+span by name + attribute) and returns compact, schema-stable JSON:
 
 ```sh
 curl -s http://localhost:8080/api/v1                  # discovery index: every route + examples
@@ -97,8 +98,11 @@ curl -s http://localhost:8080/api/v1/openapi.json     # OpenAPI 3.1, schemas inc
 curl -s http://localhost:8080/api/v1/docs             # agent guide (also /.well-known/llms.txt)
 
 curl -s 'http://localhost:8080/api/v1/search/traces?errorsOnly=true&since=1h&limit=10'
-curl -s  http://localhost:8080/api/v1/traces/$TRACE_ID/summary     # per-node rollups, no spans
-curl -s  http://localhost:8080/api/v1/traces/$TRACE_ID/aggregate   # per-node stats per code path
+curl -s  http://localhost:8080/api/v1/traces/$TRACE_ID/summary     # one node's rollup, no spans
+
+# correlate one span across nodes that each emit their OWN trace (name + attribute):
+curl -s 'http://localhost:8080/api/v1/compare?name=simplex.voter.view&nameRegex=false&attr=span.view%3D1612&since=1h'
+curl -s 'http://localhost:8080/api/v1/compare/aggregate?name=simplex.voter.view&nameRegex=false&attr=span.view%3D1612&since=1h'  # per-node stats per code path
 ```
 
 The API is self-describing (start at `GET /api/v1`); all errors are RFC 9457

--- a/skills/tracer-api/SKILL.md
+++ b/skills/tracer-api/SKILL.md
@@ -1,14 +1,16 @@
 ---
 name: tracer-api
-description: Query a deployed tracer instance (the REST middle layer over Grafana Tempo for multi-instance traces) to find slow or failing nodes, compare code paths across a cluster, drill into spans/events, and answer natural-language analytics asks ("mean/median per node over the last N rounds", "worst tail latency"). Use when the user asks about traces, spans, consensus-round timing, straggler/slow nodes, or errors in a system observed by tracer, or mentions a tracer/Tempo deployment URL.
+description: Query a deployed tracer instance (the REST middle layer over Grafana Tempo for distributed systems where each node emits its own trace) to find slow or failing nodes, compare one span across the cluster by name + attribute, drill into spans/events, and answer natural-language analytics asks ("mean/median per node over the last N rounds", "worst tail latency"). Use when the user asks about traces, spans, consensus-round timing, straggler/slow nodes, or errors in a system observed by tracer, or mentions a tracer/Tempo deployment URL.
 ---
 
 # Querying the tracer API
 
 tracer ingests nothing itself — it reads a Grafana Tempo instance and serves
-a typed REST API for traces emitted by many nodes running the SAME system
-(one trace id per logical operation, e.g. a consensus round; every node's
-spans live in that one trace, deduplicated and split per instance).
+a typed REST API for distributed systems where many nodes run the SAME system
+and EACH node emits its OWN trace. To view or compare one logical operation
+across nodes, correlate the matching span across their separate traces by span
+name + an attribute that pins the operation (e.g. a consensus view) with
+`/compare` and `/compare/aggregate`.
 
 `$BASE` below is the deployment origin, e.g. `http://localhost:8080`.
 
@@ -28,32 +30,36 @@ spans live in that one trace, deduplicated and split per instance).
   `spanStartUnixMs` are epoch MILLISECONDS; every `*Ns` field is NANOSECONDS,
   and span/event `startNs`/`timeNs` are RELATIVE to the trace's `startUnixMs`.
 - **Instances**: `service.name` + optional `#service.instance.id`
-  (`node-2`, `api#worker-001`). An instance = one node/process.
+  (`node-2`, `api#worker-001`). An instance = one node/process. A fetched trace
+  is ONE node; cross-node views come from `/compare` (which assembles one lane
+  per node).
 - **Search is "latest N in range", newest-first, deterministic.** No
   pagination — narrow or shift the range (`since=15m`, `from`/`to`) to go
   deeper.
 - Errors are RFC 9457 `application/problem+json`; on 400 read
   `invalidParams[*].reason`/`example` and fix your request.
 
-## Workflow: find the slow / failing node
+## Workflow: find the slow / failing node on an operation
+
+Each node runs the operation in its OWN trace, so correlate them by span name +
+an attribute that pins ONE operation (e.g. a consensus view).
 
 ```sh
-# 1. recent traces (add errorsOnly=true, service=, name=, attr=… to narrow)
-curl -s "$BASE/api/v1/search/traces?since=15m&limit=5"
-# 2. pre-flight ONE trace — small payload, per-instance rollups:
-#    spanCount, errorCount, earliestStartNs/latestEndNs (who started late /
-#    finished last)
-curl -s "$BASE/api/v1/traces/$TRACE_ID/summary"
-# 3. compare the same code path across nodes — flat flame nodes, each with
+# 1. resolve the span name + the pinning attribute (don't guess names)
+curl -s "$BASE/api/v1/tags/span/name/values?q=view"   # the span
+curl -s "$BASE/api/v1/tags/span/view/values"          # values that pin one operation
+# 2. per-node code-path stats for ONE operation — flat flame nodes, each with
 #    path[] and perInstance[id] = {count,minNs,maxNs,meanNs,totalNs,errorCount}
-curl -s "$BASE/api/v1/traces/$TRACE_ID/aggregate"
-# 4. only if rollups aren't enough — full spans (flat list; tree shape via
-#    parentSpanId/childSpanIds; events ride on their span). Scope it:
-curl -s "$BASE/api/v1/traces/$TRACE_ID?instance=node-2"
+curl -s "$BASE/api/v1/compare/aggregate?name=simplex.voter.view&nameRegex=false&attr=span.view%3D1612&since=1h"
+# 3. the full assembled comparison (one lane per node, aligned on the earliest start):
+curl -s "$BASE/api/v1/compare?name=simplex.voter.view&nameRegex=false&attr=span.view%3D1612&since=1h"
+# 4. one node's own trace in full (one trace = one node):
+curl -s "$BASE/api/v1/traces/$TRACE_ID"
 ```
 
-Prefer `/summary` and `/aggregate` over the full trace — they answer
-"which node was slowest / erroring on which code path" in a few KB.
+`/compare/aggregate` answers "which node was slowest / erroring on which code
+path" in a few KB; `perInstance[id].meanNs` reveals the straggler. `/summary`
+gives one node's rollup before you download its full trace.
 
 ## Natural-language analytics asks
 
@@ -62,38 +68,57 @@ Most requests arrive in workload vocabulary, not API vocabulary — e.g.
 duration over all of them; which node has the worst tail latency and how far
 behind is it?"*. The pattern, every time:
 
-**1. Resolve the user's words to real span names.** Never assume "round" /
-"commit" / "block" is a literal span name — discover it:
+**1. Resolve the user's words to a span name AND the attribute that pins one
+operation.** Never assume "round" / "commit" / "view" is a literal span name —
+discover both:
 
 ```sh
-curl -s "$BASE/api/v1/tags/span/name/values?q=round"   # substring match
-curl -s "$BASE/api/v1/tags/span/name/values"           # no hit? list all, pick the closest
+curl -s "$BASE/api/v1/tags/span/name/values?q=round"   # the span name
+curl -s "$BASE/api/v1/tags/span"                        # candidate pinning attrs (view, height, …)
+curl -s "$BASE/api/v1/tags/span/view/values"           # the operation ids to iterate
 ```
 
 A broad recent search also reveals vocabulary: `rootTraceName` in
 `/search/traces?since=15m&limit=5` rows is what the workload calls its
-top-level operation, and `/aggregate` `path[]`s name every phase.
+top-level operation, and `/compare/aggregate` `path[]`s name every phase.
 
-**2. Fetch the N matching operations.**
-`/search/traces?name=<resolved>&nameRegex=false&since=15m&limit=50`.
-If fewer rows than asked for come back, widen the range (`since=1h`, `24h`,
-…) and retry — results are "latest N in range", so a too-narrow window is
-the only reason to come up short.
+**2. Enumerate the N operations.** Each operation is one value of the pinning
+attribute (e.g. `view=1612`). Get the recent values from
+`/api/v1/tags/span/<attr>/values` (widen `since` if you need more); each value
+is one operation to compare across nodes.
 
-**3. Analyze with a script, not by eyeballing JSON.** Loop the trace ids
-through `/aggregate` (a few KB each; the server caches parses, concurrent
-fetches are fine) and compute in the script. Per-instance duration for one
-operation = `perInstance[id].maxNs` on the depth-0 node. Then aggregate
-ACROSS operations: mean / median / p95 / max per instance, deltas between an
-instance and the rest, error counts. Tail latency = the high quantiles, not
-the mean — a node can hide a terrible p95 behind a normal average.
+**3. Analyze with a script, not by eyeballing JSON.** Loop the operation values
+through `/compare/aggregate?name=<span>&nameRegex=false&attr=span.<attr>=<value>`
+(a few KB each; the server caches per-node parses, concurrent calls are fine).
+Per-instance duration for one operation = `perInstance[id].maxNs` on the
+depth-0 node. Then aggregate ACROSS operations: mean / median / p95 / max per
+instance, deltas between an instance and the rest, error counts. Tail latency =
+the high quantiles, not the mean — a node can hide a terrible p95 behind a
+normal average.
 
 **4. Report only the signal.** Lead with the direct answer to what was
 asked, then one compact table. Flag what the user didn't ask for but needs:
 outlier operations (e.g. >2× the median duration), nodes with `errorCount > 0`,
-phases that only one node executed (`/aggregate` rows whose `perInstance`
+phases that only one node executed (`/compare/aggregate` rows whose `perInstance`
 has a single key — timeouts/retries often look like this). Link the web UI
-for every trace you call out. No raw JSON dumps.
+for every operation you call out. No raw JSON dumps.
+
+## Compare across nodes (the cross-node primitive)
+
+Cross-node analysis always goes through compare, because each node emits its own
+trace. Both endpoints take the search dialect; give an exact `name`
+(`nameRegex=false`) plus an `attr` that pins one operation, or there is nothing
+to correlate on (400).
+
+- `/compare` returns the SAME shape as `/traces/:id` (a multi-instance wire
+  trace, one lane per node, aligned on the earliest match's start and
+  id-prefixed) — analyze or render it exactly like a fetched trace.
+- `/compare/aggregate` returns the merged flame: nodes per `path[]` with
+  `perInstance[id]` duration/error stats (add `spanIds=true` for the matching
+  span ids). Prefer it for "who is slow on which path" — a few KB, no spans.
+
+The UI exposes this as the **Compare** button (shareable at
+`$BASE/#/compare?...`).
 
 ## Other moves
 
@@ -113,17 +138,19 @@ for every trace you call out. No raw JSON dumps.
 
 ## Reporting
 
-When you mention a notable trace (a straggler round, an error spike, an
-outlier), include its web UI link so a human can open it directly:
-`$BASE/#/trace/<traceId>`, e.g.
-`http://localhost:8080/#/trace/85765a68a1554a3106bd2742cc56db2e`.
-The flamegraph there shows per-node lanes, the merged flame, stats, and the
-heatmap for exactly the trace you analyzed.
+When you mention a notable operation (a straggler round, an error spike, an
+outlier), include its web UI link so a human can open it directly. For a
+cross-node comparison, link the compare view:
+`$BASE/#/compare?name=<span>&nameRegex=false&attr=span.view=<id>&since=1h` —
+it shows per-node lanes, stats, and the heatmap for that operation. For a single
+node, link its trace: `$BASE/#/trace/<traceId>`.
 
 ## Don'ts
 
-- Don't fetch full traces to compute per-node timing — `/aggregate` already
-  did the cross-instance join.
+- Don't fetch full traces to compute per-node timing — `/compare/aggregate`
+  already did the cross-node join.
+- Don't expect multiple nodes in one trace — each node emits its own; cross-node
+  analysis goes through `/compare`.
 - Don't mix the time units; don't pass milliseconds to `from`/`to`.
 - Don't hardcode workload span names (`round`, `commit`, …) in reusable
-  tooling — discover names via search results or `/aggregate` paths.
+  tooling — discover names via search results or `/compare/aggregate` paths.

--- a/web/server/discovery.ts
+++ b/web/server/discovery.ts
@@ -45,7 +45,7 @@ export function makeDiscoveryRoutes(getAll: () => readonly RouteDef[]): RouteDef
             name: 'tracer API',
             version: 'v1',
             description:
-              'REST middle layer over Grafana Tempo for multi-instance traces: spans from every node sharing a trace id, deduplicated and split per instance, with merged-aggregate views for cross-node comparison.',
+              'REST middle layer over Grafana Tempo for distributed systems where each node emits its own trace. Fetch one node\'s trace, or correlate the same span across nodes by span name + attribute via /compare (and /compare/aggregate for per-node code-path stats).',
             conventions: CONVENTIONS,
             routes: getAll().map(routeEntry),
             links: {

--- a/web/server/docs.ts
+++ b/web/server/docs.ts
@@ -12,7 +12,7 @@ export const CONVENTIONS = {
     'THREE UNITS, never mixed: search ranges (`from`/`to`) are unix SECONDS; trace/span anchors (`startUnixMs`, `spanStartUnixMs`) are epoch MILLISECONDS; every `*Ns` field is NANOSECONDS — and span/event `startNs`/`timeNs` are RELATIVE to the trace `startUnixMs`, not absolute.',
   ids: 'Trace/span ids are lowercase hex in responses; hex or base64 are accepted on input.',
   instances:
-    'An instance is one emitting process (one node). Identity = resource `service.name`, plus `#service.instance.id` when present (e.g. `node-2` or `api#worker-001`). Nodes executing the same protocol share one trace id per logical operation, so one trace holds every node\'s spans — the parser splits them per instance.',
+    'An instance is one emitting process (one node). Identity = resource `service.name`, plus `#service.instance.id` when present (e.g. `node-2` or `api#worker-001`). Each node emits its OWN trace, so a fetched trace is one node; to view or aggregate the same span across nodes, use /compare and /compare/aggregate (correlate by span name + attribute).',
   dedup:
     'Spans are deduplicated by span id (first occurrence wins; a warning is recorded). Trace search rows are deduplicated by trace id, event search rows by span id + event name.',
   ordering:
@@ -29,10 +29,11 @@ export function renderDocs(routes: readonly RouteDef[]): string {
   return `# tracer API — agent guide
 
 A REST middle layer over Grafana Tempo for traces emitted by many nodes
-running the SAME system (e.g. a consensus cluster). It does the heavy
-lifting — TraceQL compilation, deterministic newest-first search, OTLP
-parsing, span dedup, per-instance splitting, cross-instance aggregation —
-and serves compact, schema-stable JSON.
+running the SAME system (e.g. a consensus cluster). Each node emits its own
+trace; the server does the heavy lifting — TraceQL compilation, deterministic
+newest-first search, OTLP parsing, span dedup, and correlating the same span
+across nodes' separate traces by name + attribute (/compare) — and serves
+compact, schema-stable JSON.
 
 Start here:
 - \`GET /api/v1\` — machine-readable index: every route, parameter, example.
@@ -58,16 +59,20 @@ ${routeLines}
 \`$BASE\` is the deployment origin, e.g. \`http://localhost:8080\` —
 \`export BASE=http://localhost:8080\` and the commands below run as-is.
 
-### Which node was slow in recent rounds?
+### Which node was slow on a given operation?
+
+Each node runs the operation in its OWN trace, so correlate them by span name +
+an attribute that pins the operation (e.g. a consensus view). /compare assembles
+the lanes; /compare/aggregate gives the per-node stats per code path directly.
 
 \`\`\`sh
-# 1. find recent traces (newest first)
-curl -s "$BASE/api/v1/search/traces?since=15m&limit=5"
-# 2. pre-flight one trace: per-instance durations + error counts, no spans
-curl -s "$BASE/api/v1/traces/$TRACE_ID/summary"
-# 3. compare the same code path across nodes: per-instance stats per path
-curl -s "$BASE/api/v1/traces/$TRACE_ID/aggregate"
-#    -> in each node, perInstance[instanceId].meanNs reveals the straggler
+# discover the span name + the attribute that identifies one operation
+curl -s "$BASE/api/v1/tags/span/name/values?q=view"
+# per-node code-path stats for that one operation, no spans downloaded:
+curl -s "$BASE/api/v1/compare/aggregate?name=simplex.voter.view&nameRegex=false&attr=span.view%3D1612&since=1h"
+#   -> on each node, perInstance[instanceId].meanNs reveals the straggler
+# or the full assembled trace (one lane per node, aligned on the earliest start):
+curl -s "$BASE/api/v1/compare?name=simplex.voter.view&nameRegex=false&attr=span.view%3D1612&since=1h"
 \`\`\`
 
 ### Chase errors
@@ -75,8 +80,8 @@ curl -s "$BASE/api/v1/traces/$TRACE_ID/aggregate"
 \`\`\`sh
 curl -s "$BASE/api/v1/search/traces?errorsOnly=true&since=1h&limit=10"
 curl -s "$BASE/api/v1/search/events?level=error&since=1h"
-# then drill into a specific instance's spans only:
-curl -s "$BASE/api/v1/traces/$TRACE_ID?instance=node-2"
+# then download the offending node's trace (one trace = one node):
+curl -s "$BASE/api/v1/traces/$TRACE_ID"
 \`\`\`
 
 ### Build filters incrementally

--- a/web/server/routes.ts
+++ b/web/server/routes.ts
@@ -7,7 +7,7 @@
 import type { RouteDef, RouteParamDoc } from './router'
 import { handleHealth } from './misc'
 import { handleCompile, handleSearchEvents, handleSearchTraces } from './search'
-import { handleTrace, handleTraceAggregate, handleTraceSummary } from './traces'
+import { handleCompare, handleCompareAggregate, handleTrace, handleTraceSummary } from './traces'
 import { handleTagNames, handleTagValues } from './tags'
 
 /** The flat GET search dialect, shared by both search routes. */
@@ -154,6 +154,38 @@ export const ROUTES: RouteDef[] = [
   },
   {
     method: 'GET',
+    pattern: '/api/v1/compare',
+    operationId: 'compareBySpan',
+    summary:
+      'Compare ONE span across nodes by correlating it in each node\'s own trace. Runs the search dialect to locate the matching span (give an exact `name` plus an `attr` that pins the operation, e.g. name=simplex.voter.view&nameRegex=false&attr=span.view=1612), then assembles each match\'s subtree into one multi-instance trace whose lanes share a time axis anchored at the EARLIEST matched span, so each node\'s start skew is visible. The response is the same shape as GET /traces/:id, so the flame/stats/heatmap views render it directly.',
+    params: SEARCH_QUERY_PARAMS,
+    responseSchema: 'wireTraceSchema',
+    example:
+      "curl -s 'http://localhost:8080/api/v1/compare?name=simplex.voter.view&nameRegex=false&attr=span.view%3D1612&since=1h'",
+    handler: handleCompare,
+  },
+  {
+    method: 'GET',
+    pattern: '/api/v1/compare/aggregate',
+    operationId: 'compareAggregate',
+    summary:
+      'The merged ("aggregate") flame tree of a comparison: the same span correlated across nodes (search dialect, e.g. name=simplex.voter.view&nameRegex=false&attr=span.view=1612), assembled and grouped by name-path with per-instance duration/error stats. The cross-node code-path view — compare the same path across every node without downloading spans.',
+    params: [
+      ...SEARCH_QUERY_PARAMS,
+      {
+        name: 'spanIds',
+        in: 'query',
+        description: 'Include per-instance matching span ids on every node (default false).',
+        example: 'true',
+      },
+    ],
+    responseSchema: 'aggregateResponseSchema',
+    example:
+      "curl -s 'http://localhost:8080/api/v1/compare/aggregate?name=simplex.voter.view&nameRegex=false&attr=span.view%3D1612&since=1h'",
+    handler: handleCompareAggregate,
+  },
+  {
+    method: 'GET',
     pattern: '/api/v1/traceql/compile',
     operationId: 'compileTraceql',
     summary:
@@ -187,7 +219,7 @@ export const ROUTES: RouteDef[] = [
     pattern: '/api/v1/traces/:traceId/summary',
     operationId: 'getTraceSummary',
     summary:
-      'Pre-flight overview of one trace: duration, span/event counts, and per-instance rollups (spanCount, errorCount, start/end extents) WITHOUT any span payload. Answers "which node was slowest / erroring" in one small response — fetch this before deciding to download the full trace.',
+      'Pre-flight overview of one trace (one node): duration, span/event counts, and rollups (spanCount, errorCount, start/end extents) WITHOUT any span payload. Fetch this before deciding to download the full trace; use /compare/aggregate to compare a span across nodes.',
     params: [
       { name: 'traceId', in: 'path', description: 'Trace id (hex; base64 also accepted).' },
     ],
@@ -197,44 +229,12 @@ export const ROUTES: RouteDef[] = [
   },
   {
     method: 'GET',
-    pattern: '/api/v1/traces/:traceId/aggregate',
-    operationId: 'getTraceAggregate',
-    summary:
-      'The merged ("aggregate") flame tree: spans from all instances grouped by name-path (the same methodology as the UI\'s merged flame), flattened to pre-ordered nodes with per-instance duration/error stats. Compare one code path across every node without downloading spans.',
-    params: [
-      { name: 'traceId', in: 'path', description: 'Trace id (hex; base64 also accepted).' },
-      {
-        name: 'instance',
-        in: 'query',
-        description: 'Limit the aggregation to these instance ids. Repeatable; omit for all.',
-        example: 'node-1',
-      },
-      {
-        name: 'spanIds',
-        in: 'query',
-        description: 'Include per-instance matching span ids on every node (default false).',
-        example: 'true',
-      },
-    ],
-    responseSchema: 'aggregateResponseSchema',
-    example:
-      'curl -s http://localhost:8080/api/v1/traces/0af7651916cd43dd8448eb211c80319c/aggregate',
-    handler: handleTraceAggregate,
-  },
-  {
-    method: 'GET',
     pattern: '/api/v1/traces/:traceId',
     operationId: 'getTrace',
     summary:
-      'One fully parsed trace: instance-split, span-deduplicated, with the tree encoded as parentSpanId/childSpanIds over a flat span list (times in ns relative to startUnixMs). The complete payload — prefer /summary and /aggregate when you only need rollups.',
+      'One fully parsed trace: span-deduplicated, with the tree encoded as parentSpanId/childSpanIds over a flat span list (times in ns relative to startUnixMs). A trace is one node\'s work — prefer /summary for rollups, and /compare to view a span across nodes.',
     params: [
       { name: 'traceId', in: 'path', description: 'Trace id (hex; base64 also accepted).' },
-      {
-        name: 'instance',
-        in: 'query',
-        description: 'Return only these instance ids (links to excluded spans are severed). Repeatable.',
-        example: 'node-1',
-      },
     ],
     responseSchema: 'wireTraceSchema',
     example: 'curl -s http://localhost:8080/api/v1/traces/0af7651916cd43dd8448eb211c80319c',

--- a/web/server/traces.test.ts
+++ b/web/server/traces.test.ts
@@ -4,7 +4,13 @@ import { parseTrace } from '../src/lib/trace'
 import { hydrateTrace, type WireTrace } from '../src/lib/wire'
 import type { AggregateResponse, TraceOverview, ApiProblem } from '../src/lib/apischema'
 import type { Deps } from './router'
-import { clearTraceCache, handleTrace, handleTraceAggregate, handleTraceSummary } from './traces'
+import {
+  clearTraceCache,
+  handleCompare,
+  handleCompareAggregate,
+  handleTrace,
+  handleTraceSummary,
+} from './traces'
 import { handleTagNames, handleTagValues } from './tags'
 
 const TRACE_HEX = '0af7651916cd43dd8448eb211c80319c'
@@ -113,54 +119,16 @@ describe('handleTrace', () => {
     expect(body.instances[1].errorCount).toBe(1)
   })
 
-  test('?instance= scopes spans and severs cross-instance child links', async () => {
-    const { body } = await get<WireTrace>(
-      handleTrace,
-      `/api/v1/traces/${TRACE_HEX}?instance=node-1`,
-      { traceId: TRACE_HEX },
-    )
-    expect(body.instances.map((i) => i.id)).toEqual(['node-1'])
-    expect(body.spans.map((s) => s.spanId)).toEqual(['aaaaaaaaaaaa0001'])
-    // node-1's root had node-2's verify as a child — severed, not dangling.
-    expect(body.spans[0].childSpanIds).toEqual([])
-  })
-
-  test('?instance= promotes spans whose parent left with another instance', async () => {
-    // node-2's verify is parented under node-1's root; scoping to node-2
-    // must promote it to a root, not strand it with a dangling parent.
-    const { body } = await get<WireTrace>(
-      handleTrace,
-      `/api/v1/traces/${TRACE_HEX}?instance=node-2`,
-      { traceId: TRACE_HEX },
-    )
-    expect(body.instances.map((i) => i.id)).toEqual(['node-2'])
-    const verify = body.spans.find((s) => s.spanId === 'bbbbbbbbbbbb0002')!
-    expect(verify.parentSpanId).toBeNull()
-    expect(verify.depth).toBe(0)
-    // promoted into rootSpanIds, in startNs order (round @100 < verify @150)
-    expect(body.instances[0].rootSpanIds).toEqual(['aaaaaaaaaaaa0002', 'bbbbbbbbbbbb0002'])
-    expect(body.instances[0].maxDepth).toBe(0)
-    // every span is reachable from rootSpanIds via childSpanIds
-    const reachable = new Set<string>()
-    const walk = (id: string): void => {
-      reachable.add(id)
-      body.spans.find((s) => s.spanId === id)!.childSpanIds.forEach(walk)
-    }
-    for (const i of body.instances) i.rootSpanIds.forEach(walk)
-    expect([...reachable].sort()).toEqual(body.spans.map((s) => s.spanId).sort())
-  })
-
-  test('unknown ?instance= 400s naming the valid ids', async () => {
-    const url = new URL(`http://x/api/v1/traces/${TRACE_HEX}?instance=node-9`)
+  test('rejects unknown query params (e.g. instance)', async () => {
+    const url = new URL(`http://x/api/v1/traces/${TRACE_HEX}?instance=node-1`)
     try {
       await handleTrace(new Request(url), url, { traceId: TRACE_HEX }, deps())
       throw new Error('expected a problem Response')
     } catch (err) {
       expect(err).toBeInstanceOf(Response)
-      const p = (await (err as Response).json()) as ApiProblem
       expect((err as Response).status).toBe(400)
-      expect(p.invalidParams?.[0].reason).toContain('node-1')
-      expect(p.invalidParams?.[0].reason).toContain('node-2')
+      const p = (await (err as Response).json()) as ApiProblem
+      expect(p.invalidParams?.[0].name).toBe('instance')
     }
   })
 
@@ -171,9 +139,7 @@ describe('handleTrace', () => {
       `/api/v1/traces/${TRACE_HEX}/summary`,
       { traceId: TRACE_HEX },
     )
-    await get<AggregateResponse>(handleTraceAggregate, `/api/v1/traces/${TRACE_HEX}/aggregate`, {
-      traceId: TRACE_HEX,
-    })
+    await get<WireTrace>(handleTrace, `/api/v1/traces/${TRACE_HEX}`, { traceId: TRACE_HEX })
     expect(fetchCount).toBe(1)
     // Age must be present so max-age=15 doesn't restart downstream.
     expect(Number.isInteger(Number(headers.get('age')))).toBe(true)
@@ -198,41 +164,168 @@ describe('handleTraceSummary', () => {
   })
 })
 
-describe('handleTraceAggregate', () => {
-  test('per-instance stats per path; pre-order; no spanIds by default', async () => {
-    const { body } = await get<AggregateResponse>(
-      handleTraceAggregate,
-      `/api/v1/traces/${TRACE_HEX}/aggregate`,
-      { traceId: TRACE_HEX },
-    )
-    expect(body.instances).toEqual(['node-1', 'node-2'])
-    const round = body.nodes.find((n) => n.path.length === 1 && n.name === 'round')!
-    expect(round.count).toBe(2)
-    expect(round.perInstance['node-1']).toEqual({
-      count: 1, minNs: 1000, maxNs: 1000, meanNs: 1000, totalNs: 1000, errorCount: 0,
-    })
-    expect(round.perInstance['node-2']).toEqual({
-      count: 1, minNs: 2000, maxNs: 2000, meanNs: 2000, totalNs: 2000, errorCount: 1,
-    })
-    expect(round.spanIds).toBeUndefined()
-    // verify rides under node-1's root in the merged tree (cross-instance child)
-    const verify = body.nodes.find((n) => n.name === 'verify')!
-    expect(verify.path).toEqual(['round', 'verify'])
-    expect(verify.depth).toBe(1)
-    // pre-order: parent before child
-    expect(body.nodes.indexOf(round)).toBeLessThan(body.nodes.indexOf(verify))
+// Two SEPARATE node traces, each with a `simplex.voter.view` span (view=1612)
+// at a DIFFERENT absolute offset — exercises rebasing and id-prefixing.
+const COMPARE_SEARCH = {
+  traces: [
+    {
+      traceID: 'aa01',
+      startTimeUnixNano: at(1000),
+      spanSets: [
+        { matched: 1, spans: [{ spanID: 'cccccccccccc0001', name: 'simplex.voter.view', attributes: [] }] },
+      ],
+    },
+    {
+      traceID: 'bb02',
+      startTimeUnixNano: at(2000),
+      spanSets: [
+        { matched: 1, spans: [{ spanID: 'cccccccccccc0002', name: 'simplex.voter.view', attributes: [] }] },
+      ],
+    },
+  ],
+}
+
+const nodeOtlp = (
+  service: string,
+  traceId: string,
+  rootId: string,
+  viewId: string,
+  voteId: string,
+  viewOff: number,
+  viewDur: number,
+) => ({
+  resourceSpans: [
+    {
+      resource: { attributes: [sattr('service.name', service)] },
+      scopeSpans: [
+        {
+          spans: [
+            { traceId, spanId: rootId, name: 'process', startTimeUnixNano: at(0), endTimeUnixNano: at(9_000_000) },
+            {
+              traceId,
+              spanId: viewId,
+              parentSpanId: rootId,
+              name: 'simplex.voter.view',
+              startTimeUnixNano: at(viewOff),
+              endTimeUnixNano: at(viewOff + viewDur),
+              attributes: [sattr('view', '1612')],
+            },
+            {
+              traceId,
+              spanId: voteId,
+              parentSpanId: viewId,
+              name: 'vote',
+              startTimeUnixNano: at(viewOff + 5),
+              endTimeUnixNano: at(viewOff + 5 + Math.floor(viewDur / 2)),
+            },
+          ],
+        },
+      ],
+    },
+  ],
+})
+
+// view offsets are whole ms so the cross-trace alignment math is exact; both
+// traces share t0 (process @ 0), so node-2 enters the view 2ms after node-1.
+const NODE1_OTLP = nodeOtlp('node-1', 'aa01', 'aaaa0000aaaa0001', 'cccccccccccc0001', 'dddd0000dddd0001', 1_000_000, 400_000)
+const NODE2_OTLP = nodeOtlp('node-2', 'bb02', 'aaaa0000aaaa0002', 'cccccccccccc0002', 'dddd0000dddd0002', 3_000_000, 600_000)
+
+describe('handleCompare', () => {
+  beforeEach(() => {
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      const url = new URL(String(input))
+      if (url.pathname === '/api/search') {
+        return Response.json(COMPARE_SEARCH)
+      }
+      if (url.pathname === '/api/v2/traces/aa01') return Response.json(NODE1_OTLP)
+      if (url.pathname === '/api/v2/traces/bb02') return Response.json(NODE2_OTLP)
+      return new Response('not found', { status: 404 })
+    }) as unknown as typeof fetch
   })
 
-  test('?instance= scoping and ?spanIds=true', async () => {
-    const { body } = await get<AggregateResponse>(
-      handleTraceAggregate,
-      `/api/v1/traces/${TRACE_HEX}/aggregate?instance=node-2&spanIds=true`,
-      { traceId: TRACE_HEX },
+  const compare = (query: string) =>
+    get<WireTrace>(handleCompare, `/api/v1/compare?${query}`, {})
+
+  test('assembles each node onto a shared axis anchored at the earliest start', async () => {
+    const { status, body } = await compare(
+      'name=simplex.voter.view&nameRegex=false&attr=span.view%3D1612&from=1749571100&to=1749571300',
     )
-    expect(body.instances).toEqual(['node-2'])
-    const round = body.nodes.find((n) => n.name === 'round')!
-    expect(round.perInstance['node-1']).toBeUndefined()
-    expect(round.spanIds).toEqual({ 'node-2': ['aaaaaaaaaaaa0002'] })
+    expect(status).toBe(200)
+    expect(body.traceId).toBe('compare')
+    // origin = earliest matched start (node-1's view, 1ms into its trace)
+    expect(body.startUnixMs).toBe(Number(T0 / 1_000_000n) + 1)
+    expect(body.instances.map((i) => i.id)).toEqual(['node-1', 'node-2'])
+
+    const rootOf = (id: string) =>
+      body.spans.find((s) => s.spanId === body.instances.find((i) => i.id === id)!.rootSpanIds[0])!
+    for (const id of ['node-1', 'node-2']) {
+      const root = rootOf(id)
+      expect(root.name).toBe('simplex.voter.view')
+      expect(root.parentSpanId).toBeNull()
+      expect(root.instanceId).toBe(id)
+    }
+    // node-1 anchors the axis; node-2 entered 2ms later and is shifted right
+    expect(rootOf('node-1').startNs).toBe(0)
+    expect(rootOf('node-2').startNs).toBe(2_000_000)
+
+    // Ids are instance-prefixed (the two source traces both used cccc...0001/2).
+    expect(body.spans.some((s) => s.spanId.startsWith('node-1::'))).toBe(true)
+    expect(body.spans.some((s) => s.spanId.startsWith('node-2::'))).toBe(true)
+    // process roots are dropped; only each view subtree (view + vote) survives.
+    expect(body.spans.map((s) => s.name).sort()).toEqual([
+      'simplex.voter.view',
+      'simplex.voter.view',
+      'vote',
+      'vote',
+    ])
+    // extent = origin to node-2's late (2ms) 0.6ms view end
+    expect(body.durationNs).toBe(2_600_000)
+
+    // The wire trace hydrates back into a usable model.
+    const model = hydrateTrace(body)
+    expect(model.instances).toHaveLength(2)
+  })
+
+  test('compare/aggregate gives per-node code-path stats over the assembly', async () => {
+    const { status, body } = await get<AggregateResponse>(
+      handleCompareAggregate,
+      '/api/v1/compare/aggregate?name=simplex.voter.view&nameRegex=false&attr=span.view%3D1612&from=1749571100&to=1749571300&spanIds=true',
+      {},
+    )
+    expect(status).toBe(200)
+    expect(body.instances).toEqual(['node-1', 'node-2'])
+    const view = body.nodes.find((n) => n.name === 'simplex.voter.view')!
+    expect(view.depth).toBe(0)
+    expect(view.count).toBe(2)
+    expect(view.perInstance['node-1'].maxNs).toBe(400_000)
+    expect(view.perInstance['node-2'].maxNs).toBe(600_000)
+    // spanIds=true surfaces the prefixed matched ids
+    expect(view.spanIds!['node-1']).toEqual(['node-1::cccccccccccc0001'])
+    // vote rides under the view in the merged tree
+    const vote = body.nodes.find((n) => n.name === 'vote')!
+    expect(vote.path).toEqual(['simplex.voter.view', 'vote'])
+    expect(vote.depth).toBe(1)
+  })
+
+  test('no spans matched: empty model carries a warning, not an error', async () => {
+    globalThis.fetch = (async () => Response.json({ traces: [] })) as unknown as typeof fetch
+    const { status, body } = await compare('name=nope&nameRegex=false&from=1749571100&to=1749571300')
+    expect(status).toBe(200)
+    expect(body.instances).toEqual([])
+    expect(body.warnings.some((w) => w.includes('no spans matched'))).toBe(true)
+  })
+
+  test('a span to correlate on is required (400 otherwise)', async () => {
+    const url = new URL('http://x/api/v1/compare?from=1749571100&to=1749571300')
+    try {
+      await handleCompare(new Request(url), url, {}, deps())
+      throw new Error('expected a problem Response')
+    } catch (err) {
+      expect(err).toBeInstanceOf(Response)
+      expect((err as Response).status).toBe(400)
+      const p = (await (err as Response).json()) as ApiProblem
+      expect(p.invalidParams?.[0].name).toBe('name')
+    }
   })
 })
 

--- a/web/server/traces.ts
+++ b/web/server/traces.ts
@@ -1,15 +1,17 @@
 /*
- * Trace handlers: the full wire trace, the pre-flight overview, and the
- * merged-aggregate view. Parsing is the shared lib (`parseTrace` via
- * TempoClient, `buildAggregateTree`); a small TTL cache absorbs the agent
- * pattern overview → aggregate → trace with a single Tempo fetch + parse,
- * inside the same 15s freshness window the Cache-Control header advertises.
+ * Trace handlers: one node's full trace and its pre-flight overview, plus the
+ * cross-node comparison (and its merged aggregate) assembled from separate
+ * per-node traces by `assembleComparison`. Parsing is the shared lib
+ * (`parseTrace` via TempoClient); a small TTL cache absorbs repeat fetches
+ * (overview -> trace, and the per-node fetches a comparison makes) with a
+ * single Tempo fetch + parse inside the 15s window the Cache-Control advertises.
  */
 
-import type { TraceModel } from '../src/lib/model'
-import { buildAggregateTree } from '../src/lib/trace'
-import { flattenAggregate, serializeTrace, type WireTrace } from '../src/lib/wire'
+import type { FilterState, SpanMatch, TimeRange, TraceModel } from '../src/lib/model'
+import { assembleComparison, buildAggregateTree } from '../src/lib/trace'
+import { flattenAggregate, serializeTrace } from '../src/lib/wire'
 import type { AggregateResponse, TraceOverview } from '../src/lib/apischema'
+import { parseSearchQuery } from './params'
 import { badRequest, type InvalidParam } from './problem'
 import { json, type Deps } from './router'
 
@@ -50,29 +52,6 @@ export function clearTraceCache(): void {
   cache.clear()
 }
 
-/**
- * Validate repeated `?instance=` params against the trace's instances.
- * Returns the selected ids (empty = all); throws a self-repairing 400 when
- * an id does not exist in this trace.
- */
-function selectedInstances(url: URL, model: TraceModel): string[] {
-  const requested = url.searchParams.getAll('instance').filter((s) => s !== '')
-  if (requested.length === 0) return []
-  const valid = new Set(model.instances.map((i) => i.id))
-  const errors: InvalidParam[] = []
-  for (const id of requested) {
-    if (!valid.has(id)) {
-      errors.push({
-        name: 'instance',
-        reason: `"${id}" is not an instance of this trace — valid: ${[...valid].join(', ')}`,
-        example: model.instances[0]?.id,
-      })
-    }
-  }
-  if (errors.length > 0) throw badRequest('Unknown instance id(s).', errors)
-  return requested
-}
-
 /** Reject query params other than the listed ones (typos fail loudly). */
 function rejectUnknownParams(url: URL, known: readonly string[]): void {
   const errors: InvalidParam[] = []
@@ -86,71 +65,15 @@ function rejectUnknownParams(url: URL, known: readonly string[]): void {
 
 // ------------------------------------------------------------------ trace --
 
-/**
- * Scope a wire trace to a subset of instances. Cross-instance links are
- * truly severed in BOTH directions: child links to excluded spans are
- * dropped, and kept spans whose parent left with another instance are
- * promoted to instance roots (parentSpanId nulled, depths recomputed) —
- * the same orphan handling the parser applies — so the tree encoding stays
- * a complete forest over the returned spans.
- */
-export function scopeWireTrace(wire: WireTrace, instanceIds: string[]): WireTrace {
-  if (instanceIds.length === 0) return wire
-  const keepInstances = new Set(instanceIds)
-  const keptSpanIds = new Set(
-    wire.spans.filter((s) => keepInstances.has(s.instanceId)).map((s) => s.spanId),
-  )
-
-  const spans = wire.spans
-    .filter((s) => keepInstances.has(s.instanceId))
-    .map((s) => ({
-      ...s,
-      parentSpanId: s.parentSpanId !== null && keptSpanIds.has(s.parentSpanId) ? s.parentSpanId : null,
-      childSpanIds: s.childSpanIds.filter((id) => keptSpanIds.has(id)),
-    }))
-
-  // Recompute depths from the (possibly promoted) roots.
-  const byId = new Map(spans.map((s) => [s.spanId, s]))
-  const queue = spans.filter((s) => s.parentSpanId === null)
-  for (const r of queue) r.depth = 0
-  for (let i = 0; i < queue.length; i++) {
-    const n = queue[i]
-    for (const id of n.childSpanIds) {
-      const child = byId.get(id)
-      if (child === undefined) continue
-      child.depth = n.depth + 1
-      queue.push(child)
-    }
-  }
-
-  const instances = wire.instances
-    .filter((i) => keepInstances.has(i.id))
-    .map((i) => {
-      const mine = spans.filter((s) => s.instanceId === i.id)
-      const roots = mine.filter((s) => s.parentSpanId === null)
-      // Parser contract: instance roots in start-time order.
-      roots.sort((a, b) => a.startNs - b.startNs)
-      return {
-        ...i,
-        rootSpanIds: roots.map((s) => s.spanId),
-        maxDepth: mine.reduce((d, s) => Math.max(d, s.depth), 0),
-      }
-    })
-
-  return { ...wire, instances, spans }
-}
-
 export async function handleTrace(
   _req: Request,
   url: URL,
   params: Record<string, string>,
   deps: Deps,
 ): Promise<Response> {
-  rejectUnknownParams(url, ['instance'])
+  rejectUnknownParams(url, [])
   const { model, at } = await loadTrace(params.traceId, deps)
-  const selected = selectedInstances(url, model)
-  const body: WireTrace = scopeWireTrace(serializeTrace(model), selected)
-  return json(body, 200, cacheHeaders(at))
+  return json(serializeTrace(model), 200, cacheHeaders(at))
 }
 
 // ---------------------------------------------------------------- summary --
@@ -176,34 +99,120 @@ export async function handleTraceSummary(
   return json(body, 200, cacheHeaders(at))
 }
 
-// -------------------------------------------------------------- aggregate --
+// ---------------------------------------------------------------- compare --
 
-export async function handleTraceAggregate(
+/** Synthetic trace id for an assembled comparison (it is not a real trace). */
+const COMPARE_TRACE_ID = 'compare'
+
+/** A comparison needs one span kind to correlate on; reject an empty target. */
+function requireCorrelator(filter: FilterState): void {
+  if (filter.name.trim() === '' && filter.rawQuery.trim() === '') {
+    throw badRequest('A comparison needs a span to correlate on.', [
+      {
+        name: 'name',
+        reason:
+          'give an exact span name (add an `attr` to pin the operation, e.g. attr=span.view=1612) or a raw `q`',
+        example: 'simplex.voter.view',
+      },
+    ])
+  }
+}
+
+/**
+ * Locate the span matching the search filter (a span name plus an attribute) in
+ * each node's own trace and assemble every match's subtree into one synthetic
+ * multi-instance trace: lanes share a time axis anchored at the earliest match,
+ * span ids instance-prefixed. Per-trace fetch failures become warnings rather
+ * than failing the request.
+ */
+async function assembleFromQuery(
+  filter: FilterState,
+  range: TimeRange,
+  deps: Deps,
+): Promise<TraceModel> {
+  const targets = (await deps.tempo.searchTraces(filter, range)).filter(
+    (s) => s.matchedSpanIds.length > 0,
+  )
+  const loaded = await Promise.all(
+    targets.map((s) =>
+      loadTrace(s.traceId, deps)
+        .then(({ model }) => ({ s, model }))
+        .catch((err) => ({ s, err: err instanceof Error ? err.message : String(err) })),
+    ),
+  )
+
+  const matches: SpanMatch[] = []
+  const warnings: string[] = []
+  const usedIds = new Set<string>()
+  for (const entry of loaded) {
+    if ('err' in entry) {
+      warnings.push(`trace ${entry.s.traceId}: ${entry.err}`)
+      continue
+    }
+    const byInstance = new Map(entry.model.instances.map((i) => [i.id, i]))
+    for (const spanId of entry.s.matchedSpanIds) {
+      const root = entry.model.spans.get(spanId)
+      if (root === undefined) continue
+      const instance = byInstance.get(root.instanceId)
+      if (instance === undefined) continue
+      let id = instance.id
+      if (usedIds.has(id)) id = `${instance.id}#${entry.s.traceId.slice(0, 6)}`
+      if (usedIds.has(id)) id = `${instance.id}#${root.spanId.slice(0, 8)}`
+      usedIds.add(id)
+      matches.push({ instance: { ...instance, id }, root, startUnixMs: entry.model.startUnixMs })
+    }
+  }
+
+  const model = assembleComparison(matches, COMPARE_TRACE_ID)
+  model.warnings.push(...warnings)
+  if (matches.length === 0) {
+    const what = filter.name.trim() !== '' ? `name "${filter.name.trim()}"` : 'the query'
+    model.warnings.push(`no spans matched ${what} with these filters in this range`)
+  }
+  return model
+}
+
+/**
+ * Compare one span across nodes whose traces are SEPARATE. Returns the same
+ * `WireTrace` shape as GET /traces/:id (one lane per node, aligned on the
+ * earliest match's start), so the flame/stats/heatmap views render it directly.
+ */
+export async function handleCompare(
   _req: Request,
   url: URL,
-  params: Record<string, string>,
+  _params: Record<string, string>,
   deps: Deps,
 ): Promise<Response> {
-  rejectUnknownParams(url, ['instance', 'spanIds'])
-  const { model, at } = await loadTrace(params.traceId, deps)
-  const selected = selectedInstances(url, model)
+  const { filter, range } = parseSearchQuery(url)
+  requireCorrelator(filter)
+  const model = await assembleFromQuery(filter, range, deps)
+  return json(serializeTrace(model), 200)
+}
 
+/**
+ * The merged aggregate of a comparison: the assembled multi-instance trace
+ * grouped by name-path, with per-instance duration/error stats for every node
+ * at each path. Compact cross-node code-path stats without downloading spans.
+ */
+export async function handleCompareAggregate(
+  _req: Request,
+  url: URL,
+  _params: Record<string, string>,
+  deps: Deps,
+): Promise<Response> {
+  const { filter, range } = parseSearchQuery(url, ['spanIds'])
+  requireCorrelator(filter)
   const spanIdsRaw = url.searchParams.get('spanIds')
   if (spanIdsRaw !== null && spanIdsRaw !== 'true' && spanIdsRaw !== 'false') {
     throw badRequest('Invalid spanIds parameter.', [
       { name: 'spanIds', reason: `expected "true" or "false", got "${spanIdsRaw}"`, example: 'true' },
     ])
   }
-
-  const included =
-    selected.length === 0 ? model.instances.map((i) => i.id) : selected
-  const keep = new Set(included)
-  const hidden = new Set(model.instances.map((i) => i.id).filter((id) => !keep.has(id)))
-
+  const model = await assembleFromQuery(filter, range, deps)
   const body: AggregateResponse = {
     traceId: model.traceId,
-    instances: included,
-    nodes: flattenAggregate(buildAggregateTree(model, hidden), spanIdsRaw === 'true'),
+    instances: model.instances.map((i) => i.id),
+    nodes: flattenAggregate(buildAggregateTree(model, new Set()), spanIdsRaw === 'true'),
   }
-  return json(body, 200, cacheHeaders(at))
+  return json(body, 200)
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,7 +2,7 @@ import { keepPreviousData, useQuery } from '@tanstack/react-query'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faFileExport, faMoon, faSun } from '@fortawesome/free-solid-svg-icons'
-import { ApiClient } from './api/client'
+import { ApiClient, buildCompareQuery } from './api/client'
 import EventDetails from './components/EventDetails'
 import ExportModal from './components/ExportModal'
 import EventsView from './components/EventsView'
@@ -28,11 +28,18 @@ import './App.css'
 
 // ----------------------------------------------------------------- routing --
 
-type Route = { view: 'search' } | { view: 'trace'; traceId: string }
+type Route =
+  | { view: 'search' }
+  | { view: 'trace'; traceId: string }
+  | { view: 'compare'; query: string }
 
 function parseHash(): Route {
-  const m = /^#\/trace\/([0-9a-fA-F]+)/.exec(window.location.hash)
-  return m ? { view: 'trace', traceId: m[1].toLowerCase() } : { view: 'search' }
+  const hash = window.location.hash
+  const tm = /^#\/trace\/([0-9a-fA-F]+)/.exec(hash)
+  if (tm) return { view: 'trace', traceId: tm[1].toLowerCase() }
+  const cm = /^#\/compare(?:\?(.*))?$/.exec(hash)
+  if (cm) return { view: 'compare', query: cm[1] ?? '' }
+  return { view: 'search' }
 }
 
 function useRoute(): [Route, (r: Route) => void] {
@@ -43,7 +50,12 @@ function useRoute(): [Route, (r: Route) => void] {
     return () => window.removeEventListener('hashchange', onHash)
   }, [])
   const navigate = useCallback((r: Route) => {
-    window.location.hash = r.view === 'trace' ? `/trace/${r.traceId}` : '/search'
+    window.location.hash =
+      r.view === 'trace'
+        ? `/trace/${r.traceId}`
+        : r.view === 'compare'
+          ? `/compare?${r.query}`
+          : '/search'
   }, [])
   return [route, navigate]
 }
@@ -143,6 +155,14 @@ export default function App() {
     }))
   }, [])
 
+  // Compare the current span name + attributes across instances: snapshot the
+  // draft filter and resolved range into the URL hash and switch to the
+  // comparison view (which assembles one synthetic multi-instance trace).
+  const onCompare = useCallback(() => {
+    const query = buildCompareQuery(filterRef.current, resolveRange(rangeRef.current, Date.now()))
+    navigate({ view: 'compare', query })
+  }, [navigate])
+
   // Switching the results tab re-submits the current filter for the new
   // target right away.
   const onTargetChange = useCallback(
@@ -195,7 +215,19 @@ export default function App() {
     queryFn: () => client.fetchTrace(traceId!),
     enabled: traceId !== null,
   })
-  const model = trace.data ?? null
+
+  // The comparison view assembles its own synthetic trace from the hash query.
+  const compareQuery = route.view === 'compare' ? route.query : null
+  const compare = useQuery({
+    queryKey: ['compare', compareQuery],
+    queryFn: () => client.compareByQuery(compareQuery!),
+    enabled: compareQuery !== null,
+  })
+
+  // Both views feed the same trace UI; `viewKey` identifies the current one.
+  const active = route.view === 'compare' ? compare : trace
+  const model = active.data ?? null
+  const viewKey = route.view === 'compare' ? `compare:${route.query}` : traceId
 
   const [tab, setTab] = useState<'flame' | 'events' | 'stats' | 'heatmap'>('flame')
   // The details pane shows either a span or an event.
@@ -234,17 +266,17 @@ export default function App() {
     )
   }, [model])
 
-  // Reset per-trace UI state when switching traces.
-  const lastTraceRef = useRef<string | null>(null)
+  // Reset per-trace UI state when switching traces or comparisons.
+  const lastViewRef = useRef<string | null>(null)
   useEffect(() => {
-    if (traceId !== lastTraceRef.current) {
-      lastTraceRef.current = traceId
+    if (viewKey !== lastViewRef.current) {
+      lastViewRef.current = viewKey
       setSelected(null)
       setHiddenInstances(new Set())
       setExportOpen(false)
       setTab('flame')
     }
-  }, [traceId])
+  }, [viewKey])
 
   // When a trace is opened from search results, carry the search context in:
   // hide instances the service filter excluded. Opening an EVENT result also
@@ -320,6 +352,14 @@ export default function App() {
           </div>
         )}
 
+        {route.view === 'compare' && (
+          <div className="app-tracebar">
+            <span className="app-traceid" title="cross-instance comparison">
+              compare
+            </span>
+          </div>
+        )}
+
         <div className="app-topbar-spacer" />
 
         <div className="app-topbar-end">
@@ -349,6 +389,7 @@ export default function App() {
             range={range}
             onRangeChange={onRangeChange}
             onSearch={onSearch}
+            onCompare={onCompare}
             searching={search.isFetching}
             client={client}
           />
@@ -371,19 +412,25 @@ export default function App() {
           />
         </main>
       ) : (
-        <main className="app-main app-trace view-fade" key={route.traceId}>
-          {trace.isLoading && (
+        <main className="app-main app-trace view-fade" key={viewKey ?? 'view'}>
+          {active.isLoading && (
             <div className="empty-state">
               <div className="spinner" />
-              loading trace…
+              {route.view === 'compare' ? 'assembling comparison…' : 'loading trace…'}
             </div>
           )}
-          {trace.error != null && (
+          {active.error != null && (
             <div className="empty-state app-error">
-              failed to load trace: {String(trace.error)}
+              {route.view === 'compare' ? 'failed to assemble comparison: ' : 'failed to load trace: '}
+              {String(active.error)}
             </div>
           )}
-          {model && (
+          {model && model.instances.length === 0 && (
+            <div className="empty-state">
+              {model.warnings[0] ?? 'no spans matched this comparison'}
+            </div>
+          )}
+          {model && model.instances.length > 0 && (
             <>
               <div className="app-trace-toolbar">
                 <div className="app-tabs">

--- a/web/src/api/client.test.ts
+++ b/web/src/api/client.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'bun:test'
 import type { FilterState } from '../lib/model'
-import { sanitizeFilter } from './client'
+import { buildCompareQuery, sanitizeFilter } from './client'
 
 const base: FilterState = {
   services: [],
@@ -41,5 +41,43 @@ describe('sanitizeFilter', () => {
       minDuration: '100ms',
     }
     expect(sanitizeFilter(f)).toEqual(f)
+  })
+})
+
+describe('buildCompareQuery', () => {
+  test('serializes name + attr + range into the compare GET dialect', () => {
+    const q = buildCompareQuery(
+      {
+        ...base,
+        name: 'simplex.voter.view',
+        nameIsRegex: false,
+        attrs: [{ id: 'a', scope: 'span', key: 'view', op: '=', value: '1612' }],
+        limit: 30,
+      },
+      { from: 1749571100.4, to: 1749571300.6 },
+    )
+    const p = new URLSearchParams(q)
+    expect(p.get('name')).toBe('simplex.voter.view')
+    expect(p.get('nameRegex')).toBe('false')
+    expect(p.get('attr')).toBe('span.view=1612')
+    expect(p.get('limit')).toBe('30')
+    // range is floored/ceiled to whole unix seconds
+    expect(p.get('from')).toBe('1749571100')
+    expect(p.get('to')).toBe('1749571301')
+  })
+
+  test('drops draft noise so a UI search compares cleanly', () => {
+    const q = buildCompareQuery(
+      {
+        ...base,
+        name: 'x',
+        attrs: [{ id: 'a', scope: 'span', key: '', op: '=', value: 'ignored' }],
+        minDuration: '150',
+      },
+      { from: 1, to: 2 },
+    )
+    const p = new URLSearchParams(q)
+    expect(p.getAll('attr')).toEqual([])
+    expect(p.has('minDuration')).toBe(false)
   })
 })

--- a/web/src/api/client.ts
+++ b/web/src/api/client.ts
@@ -46,6 +46,30 @@ export function sanitizeFilter(filter: FilterState): FilterState {
   }
 }
 
+/**
+ * Serialize a (filter, range) pair into the GET search dialect the compare
+ * route consumes. Draft noise is dropped first (sanitizeFilter), so a search
+ * that ran in the UI compares cleanly too. The query is stored in the URL hash
+ * (`#/compare?...`), making a comparison shareable and reloadable.
+ */
+export function buildCompareQuery(filter: FilterState, range: TimeRange): string {
+  const f = sanitizeFilter(filter)
+  const p = new URLSearchParams()
+  for (const s of f.services) p.append('service', s)
+  if (f.name.trim() !== '') p.set('name', f.name)
+  p.set('nameRegex', String(f.nameIsRegex))
+  for (const l of f.levels) p.append('level', l)
+  if (f.errorsOnly) p.set('errorsOnly', 'true')
+  if (f.minDuration.trim() !== '') p.set('minDuration', f.minDuration)
+  if (f.maxDuration.trim() !== '') p.set('maxDuration', f.maxDuration)
+  for (const a of f.attrs) p.append('attr', `${a.scope}.${a.key}${a.op}${a.value}`)
+  if (f.rawQuery.trim() !== '') p.set('q', f.rawQuery)
+  p.set('limit', String(f.limit))
+  p.set('from', String(Math.floor(range.from)))
+  p.set('to', String(Math.ceil(range.to)))
+  return p.toString()
+}
+
 export class ApiClient implements ITempoClient {
   readonly baseUrl: string
 
@@ -123,6 +147,16 @@ export class ApiClient implements ITempoClient {
       'GET',
       `/traces/${encodeURIComponent(traceId)}`,
     )) as WireTrace
+    return hydrateTrace(wire)
+  }
+
+  /**
+   * Assemble a cross-trace comparison. `query` is the GET search dialect from
+   * `buildCompareQuery`; the server returns one synthetic multi-instance trace
+   * (one lane per matched span, aligned on the earliest match's start).
+   */
+  async compareByQuery(query: string): Promise<TraceModel> {
+    const wire = (await this.request('GET', `/compare?${query}`)) as WireTrace
     return hydrateTrace(wire)
   }
 

--- a/web/src/components/SearchPanel.css
+++ b/web/src/components/SearchPanel.css
@@ -197,11 +197,16 @@
 /* ---------------------------------------------------------------- footer -- */
 
 .sp-footer {
+  display: flex;
+  gap: var(--pad);
   padding: var(--pad);
   border-top: 1px solid var(--border);
 }
 .sp-search {
-  width: 100%;
+  flex: 1;
+  justify-content: center;
+}
+.sp-compare {
   justify-content: center;
 }
 .sp-search .spinner {

--- a/web/src/components/SearchPanel.tsx
+++ b/web/src/components/SearchPanel.tsx
@@ -23,6 +23,7 @@ export default function SearchPanel({
   range,
   onRangeChange,
   onSearch,
+  onCompare,
   searching,
   client,
 }: SearchPanelProps) {
@@ -337,6 +338,15 @@ export default function SearchPanel({
         >
           {searching && <span className="spinner" aria-hidden="true" />}
           {searching ? 'searching…' : 'Search'}
+        </button>
+        <button
+          type="button"
+          className="btn btn-ghost sp-compare"
+          disabled={filter.name.trim() === '' && filter.rawQuery.trim() === ''}
+          title="assemble the matching span across every node into one comparison view"
+          onClick={onCompare}
+        >
+          Compare
         </button>
       </div>
     </div>

--- a/web/src/lib/apischema.ts
+++ b/web/src/lib/apischema.ts
@@ -183,7 +183,7 @@ export const wireInstanceSchema = {
 
 export const wireTraceSchema = {
   description:
-    'A fully parsed trace: spans from every instance (node) that contributed, deduplicated and split per instance. Span times are nanoseconds relative to `startUnixMs`.',
+    'A fully parsed trace: a flat span list with the tree encoded by parentSpanId/childSpanIds. From /traces/:id it is one node; from /compare it is the same span assembled across nodes (one instance per node) on a shared time axis anchored at the earliest node, so start skew is visible. Span times are nanoseconds relative to `startUnixMs`.',
   type: 'object',
   additionalProperties: false,
   properties: {

--- a/web/src/lib/model.ts
+++ b/web/src/lib/model.ts
@@ -125,6 +125,25 @@ export interface TraceModel {
   warnings: string[]
 }
 
+// ------------------------------------------------------------ comparison --
+
+/**
+ * One node's contribution to a cross-trace comparison: the span that matched
+ * the compare query (a span name plus an attribute) and the `Instance` that
+ * emitted it. Each match's subtree becomes one lane in the assembled
+ * comparison trace.
+ */
+export interface SpanMatch {
+  instance: Instance
+  root: SpanNode
+  /**
+   * Epoch ms of the source trace's earliest span, used to place this lane on
+   * the shared time axis: the root's absolute start is
+   * `startUnixMs + root.startNs / 1e6`.
+   */
+  startUnixMs: number
+}
+
 // ----------------------------------------------------- aggregated flame --
 
 /**
@@ -294,6 +313,8 @@ export interface SearchPanelProps {
   range: RangeSelection
   onRangeChange: (r: RangeSelection) => void
   onSearch: () => void
+  /** Assemble a cross-instance comparison of the current span name + attrs. */
+  onCompare: () => void
   searching: boolean
   client: ITempoClient
 }

--- a/web/src/lib/trace.test.ts
+++ b/web/src/lib/trace.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'bun:test'
-import { buildAggregateTree, parseTrace } from './trace'
+import { assembleComparison, buildAggregateTree, parseTrace } from './trace'
 import { colorIndexForService } from './model'
-import type { TraceModel } from './model'
+import type { SpanMatch, TraceModel } from './model'
 
 /*
  * Handcrafted OTLP JSON fixtures. All absolute times are e18-magnitude
@@ -605,5 +605,97 @@ describe('buildAggregateTree', () => {
     expect(verify.totalNs).toBe(10 + 30 + 20)
     expect(verify.minNs).toBe(10)
     expect(verify.maxNs).toBe(30)
+  })
+})
+
+// ------------------------------------------------------- assembleComparison --
+
+/** One node's natural trace: a `view` span (with a `vote` child) under a root. */
+function nodeTrace(service: string, viewStartOff: number, viewDur: number): TraceModel {
+  const raw = {
+    resourceSpans: [
+      group(service, [
+        mkSpan({ id: 'aaaaaaaaaaaa0001', name: 'process', start: at(0), end: at(10000) }),
+        mkSpan({
+          id: 'cccccccccccc0001',
+          parent: 'aaaaaaaaaaaa0001',
+          name: 'simplex.voter.view',
+          start: at(viewStartOff),
+          end: at(viewStartOff + viewDur),
+          attrs: [sattr('view', '1612')],
+        }),
+        mkSpan({
+          id: 'dddddddddddd0001',
+          parent: 'cccccccccccc0001',
+          name: 'vote',
+          start: at(viewStartOff + 5),
+          end: at(viewStartOff + 5 + Math.floor(viewDur / 2)),
+        }),
+      ]),
+    ],
+  }
+  return parseTrace(raw, `${service}feed`)
+}
+
+function matchFor(model: TraceModel): SpanMatch {
+  const root = [...model.spans.values()].find((s) => s.name === 'simplex.voter.view')!
+  return { instance: model.instances[0], root, startUnixMs: model.startUnixMs }
+}
+
+describe('assembleComparison', () => {
+  test('aligns lanes on the earliest start (skew preserved), prefixes ids, promotes root', () => {
+    // Both nodes share a trace t0 (`process` @ 0); node-1 enters the view at
+    // 1ms, node-2 at 3ms. The comparison must anchor the axis at the earliest
+    // (node-1 -> 0) and shift node-2 right by its real 2ms skew, NOT
+    // left-align both. ms-scale offsets keep the cross-trace math exact.
+    const a = nodeTrace('node-1', 1_000_000, 400_000)
+    const b = nodeTrace('node-2', 3_000_000, 600_000)
+    // Pass reversed to prove the origin is order-independent (min, not first).
+    const model = assembleComparison([matchFor(b), matchFor(a)], 'compare')
+
+    expect(model.traceId).toBe('compare')
+    expect(model.startUnixMs).toBe(Number(T0 / 1_000_000n) + 1) // earliest absolute start
+    expect(model.instances.map((i) => i.id)).toEqual(['node-1', 'node-2'])
+
+    const byId = new Map(model.instances.map((i) => [i.id, i.rootSpans[0]]))
+    const n1 = byId.get('node-1')!
+    const n2 = byId.get('node-2')!
+    for (const root of [n1, n2]) {
+      expect(root.name).toBe('simplex.voter.view')
+      expect(root.parentSpanId).toBeNull()
+      expect(root.depth).toBe(0)
+      expect(root.children).toHaveLength(1)
+    }
+    // earliest lane anchors the axis; the later node is shifted by its skew
+    expect(n1.startNs).toBe(0)
+    expect(n2.startNs).toBe(2_000_000)
+    // the `vote` child rides along: within-lane offset stays exact
+    expect(n1.children[0].startNs).toBe(5)
+    expect(n2.children[0].startNs).toBe(2_000_005)
+    expect(n1.children[0].depth).toBe(1)
+
+    // extent = earliest origin to the latest end (node-2's 2ms-late 0.6ms view)
+    expect(model.durationNs).toBe(2_600_000)
+    // ids are instance-prefixed so the two traces' identical ids never collide
+    expect(model.spans.has('node-1::cccccccccccc0001')).toBe(true)
+    expect(model.spans.has('node-2::cccccccccccc0001')).toBe(true)
+    expect(model.spans.size).toBe(4)
+  })
+
+  test('a single match anchors at 0; subtree spanCount/maxDepth are right', () => {
+    const a = nodeTrace('node-1', 500_000, 200_000)
+    const model = assembleComparison([matchFor(a)], 'compare')
+    expect(model.instances).toHaveLength(1)
+    expect(model.instances[0].rootSpans[0].startNs).toBe(0)
+    expect(model.instances[0].spanCount).toBe(2)
+    expect(model.instances[0].maxDepth).toBe(1)
+    expect(model.durationNs).toBe(200_000)
+  })
+
+  test('empty matches yield an empty but valid model', () => {
+    const model = assembleComparison([], 'compare')
+    expect(model.instances).toEqual([])
+    expect(model.spans.size).toBe(0)
+    expect(model.durationNs).toBe(0)
   })
 })

--- a/web/src/lib/trace.ts
+++ b/web/src/lib/trace.ts
@@ -16,6 +16,7 @@ import {
   type Level,
   type SpanEvent,
   type SpanKind,
+  type SpanMatch,
   type SpanNode,
   type SpanStatus,
   type TraceModel,
@@ -539,4 +540,108 @@ export function buildAggregateTree(model: TraceModel, hidden: ReadonlySet<string
   }
   if (rootSpans.length > 0) aggregateInto(root, rootSpans, hidden)
   return root
+}
+
+// --------------------------------------------------------- comparison --
+
+/**
+ * Assemble per-node span matches into one synthetic multi-instance trace for
+ * side-by-side comparison. The shared time axis is anchored at the EARLIEST
+ * matched span across all nodes; each lane is then offset by that node's real
+ * skew, so a node that entered the operation late renders shifted right rather
+ * than left-aligned. Span ids are prefixed with the instance id so ids drawn
+ * from separate source traces never collide. The result is a normal
+ * `TraceModel` that the flame, stats, and heatmap views render directly.
+ *
+ * Inter-lane offsets pass through the millisecond-domain `startUnixMs`, so skew
+ * is accurate to well under a microsecond (within-lane offsets stay exact).
+ *
+ * Callers must pass matches whose `instance.id`s are unique; the prefix relies
+ * on it to keep span ids globally distinct.
+ */
+export function assembleComparison(matches: SpanMatch[], traceId: string): TraceModel {
+  const spans = new Map<string, SpanNode>()
+  const events: SpanEvent[] = []
+  const instances: Instance[] = []
+  let durationNs = 0
+
+  // Absolute start of a match's root (epoch ms) and the shared origin.
+  const absMs = (m: SpanMatch): number => m.startUnixMs + m.root.startNs / 1e6
+  const originMs = matches.reduce((min, m) => Math.min(min, absMs(m)), Infinity)
+
+  for (const match of matches) {
+    const { instance, root } = match
+    const instanceId = instance.id
+    const prefix = (id: string): string => `${instanceId}::${id}`
+    const baseDepth = root.depth
+    const laneOffsetNs = Math.round((absMs(match) - originMs) * 1e6)
+    // Map a source time (relative to the node's own trace) onto the shared axis.
+    const reb = (t: number): number => laneOffsetNs + (t - root.startNs)
+
+    // Collect the matched span and its descendants. The parser guarantees
+    // `children` is a true forest, so this plain stack walk terminates.
+    const subtree: SpanNode[] = []
+    const stack: SpanNode[] = [root]
+    while (stack.length > 0) {
+      const n = stack.pop()
+      if (n === undefined) continue
+      subtree.push(n)
+      for (const c of n.children) stack.push(c)
+    }
+
+    const cloned = new Map<string, SpanNode>()
+    let maxDepth = 0
+    for (const n of subtree) {
+      const isRoot = n.spanId === root.spanId
+      const startNs = reb(n.startNs)
+      const depth = n.depth - baseDepth
+      if (depth > maxDepth) maxDepth = depth
+      if (startNs + n.durationNs > durationNs) durationNs = startNs + n.durationNs
+      const node: SpanNode = {
+        ...n,
+        spanId: prefix(n.spanId),
+        parentSpanId: isRoot || n.parentSpanId === null ? null : prefix(n.parentSpanId),
+        startNs,
+        instanceId,
+        depth,
+        events: n.events.map((e) => ({
+          ...e,
+          spanId: prefix(e.spanId),
+          instanceId,
+          timeNs: reb(e.timeNs),
+        })),
+        children: [],
+      }
+      cloned.set(node.spanId, node)
+      spans.set(node.spanId, node)
+      events.push(...node.events)
+    }
+
+    // Re-link children within the cloned subtree (parser sibling order).
+    for (const node of cloned.values()) {
+      if (node.parentSpanId === null) continue
+      cloned.get(node.parentSpanId)?.children.push(node)
+    }
+    for (const node of cloned.values()) node.children.sort((a, b) => a.startNs - b.startNs)
+
+    const clonedRoot = cloned.get(prefix(root.spanId))
+    if (clonedRoot === undefined) continue
+    instances.push({
+      id: instanceId,
+      serviceName: instance.serviceName,
+      instanceTag: instance.instanceTag,
+      colorIndex: instance.colorIndex,
+      spanCount: subtree.length,
+      rootSpans: [clonedRoot],
+      maxDepth,
+    })
+  }
+
+  events.sort((a, b) => a.timeNs - b.timeNs)
+  instances.sort(
+    (a, b) => naturalCompare(a.serviceName, b.serviceName) || naturalCompare(a.id, b.id),
+  )
+
+  const startUnixMs = Number.isFinite(originMs) ? originMs : 0
+  return { traceId, startUnixMs, durationNs, instances, spans, events, warnings: [] }
 }


### PR DESCRIPTION
Instead of comparing across a single traceID, compare across name + attribute (allows anything to be compared rather than just what has been pre-configured to share a single traceID).

This PR lays the foundation but the ergonomics are pretty poor. I think this could be improved a good bit before merging.